### PR TITLE
Add simple TypeScript frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
-# Traq
+# Traqtion
+
+This repository includes an ASP.NET Core API (under `Tq.Api`) and a simple TypeScript front‑end located in `frontend/`.
+
+## Frontend
+
+The front end is a small demo that consumes all API endpoints using AJAX calls. It uses **Tailwind CSS** via CDN and **tsParticles** for a dynamic background.
+
+### Building
+
+Compile the TypeScript sources:
+
+```bash
+npx tsc -p frontend
+```
+
+This will output JavaScript files to `frontend/dist/`.
+
+### Running
+
+Open `frontend/index.html` in a browser. Ensure the API is running on the same host/port or adjust `API_BASE` in `frontend/src/main.ts`.
+
+## Backend
+
+Run the ASP.NET Core API using the standard `dotnet run` command inside `Tq.Api`.

--- a/frontend/dist/main.js
+++ b/frontend/dist/main.js
@@ -1,0 +1,74 @@
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+const API_BASE = '/api';
+function fetchJson(url_1) {
+    return __awaiter(this, arguments, void 0, function* (url, options = {}) {
+        const response = yield fetch(url, Object.assign({ headers: {
+                'Content-Type': 'application/json'
+            } }, options));
+        if (!response.ok) {
+            const text = yield response.text();
+            throw new Error(text || response.statusText);
+        }
+        return response.json();
+    });
+}
+function loadData() {
+    return __awaiter(this, void 0, void 0, function* () {
+        try {
+            const persons = yield fetchJson(`${API_BASE}/persons`);
+            displayList('personsList', persons);
+            const accounts = yield fetchJson(`${API_BASE}/accounts`);
+            displayList('accountsList', accounts);
+            const transactions = yield fetchJson(`${API_BASE}/transactions`);
+            displayList('transactionsList', transactions);
+        }
+        catch (err) {
+            alert(err);
+        }
+    });
+}
+function displayList(elementId, data) {
+    const el = document.getElementById(elementId);
+    el.textContent = JSON.stringify(data, null, 2);
+}
+function addPerson(ev) {
+    return __awaiter(this, void 0, void 0, function* () {
+        ev.preventDefault();
+        const form = ev.target;
+        const person = {
+            idNumber: form.elements.namedItem('idNumber').value,
+            firstName: form.elements.namedItem('firstName').value,
+            lastName: form.elements.namedItem('lastName').value,
+            dateOfBirth: form.elements.namedItem('dateOfBirth').value
+        };
+        yield fetchJson(`${API_BASE}/persons`, {
+            method: 'POST',
+            body: JSON.stringify(person)
+        });
+        loadData();
+        form.reset();
+    });
+}
+document.addEventListener('DOMContentLoaded', () => {
+    loadData();
+    const personForm = document.getElementById('personForm');
+    personForm.addEventListener('submit', addPerson);
+    // tsParticles init using global variable from CDN
+    // @ts-ignore
+    tsParticles.load('tsparticles', {
+        particles: {
+            number: { value: 40 },
+            size: { value: 3 },
+            move: { enable: true, speed: 1 }
+        }
+    });
+});

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Traqtion Frontend</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script type="module" src="./dist/main.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/tsparticles-engine"></script>
+</head>
+<body class="bg-gray-900 text-white">
+  <div id="tsparticles" class="fixed top-0 left-0 w-full h-full -z-10"></div>
+  <div class="container mx-auto p-4">
+    <h1 class="text-2xl font-bold mb-4">Traqtion Dashboard</h1>
+    <form id="personForm" class="space-y-2 mb-4 bg-gray-800 p-4 rounded">
+      <h2 class="text-xl">Add Person</h2>
+      <input name="idNumber" placeholder="ID Number" class="w-full p-2 text-black" required>
+      <input name="firstName" placeholder="First Name" class="w-full p-2 text-black" required>
+      <input name="lastName" placeholder="Last Name" class="w-full p-2 text-black" required>
+      <input type="date" name="dateOfBirth" class="w-full p-2 text-black" required>
+      <button type="submit" class="bg-blue-500 px-4 py-2 text-white">Create</button>
+    </form>
+    <div>
+      <h2 class="text-xl font-semibold">Persons</h2>
+      <pre id="personsList" class="bg-gray-800 p-2 rounded"></pre>
+    </div>
+    <div>
+      <h2 class="text-xl font-semibold">Accounts</h2>
+      <pre id="accountsList" class="bg-gray-800 p-2 rounded"></pre>
+    </div>
+    <div>
+      <h2 class="text-xl font-semibold">Transactions</h2>
+      <pre id="transactionsList" class="bg-gray-800 p-2 rounded"></pre>
+    </div>
+  </div>
+</body>
+</html>

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,0 +1,68 @@
+const API_BASE = '/api';
+
+async function fetchJson(url: string, options: RequestInit = {}) {
+  const response = await fetch(url, {
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    ...options
+  });
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(text || response.statusText);
+  }
+  return response.json();
+}
+
+async function loadData() {
+  try {
+    const persons = await fetchJson(`${API_BASE}/persons`);
+    displayList('personsList', persons);
+
+    const accounts = await fetchJson(`${API_BASE}/accounts`);
+    displayList('accountsList', accounts);
+
+    const transactions = await fetchJson(`${API_BASE}/transactions`);
+    displayList('transactionsList', transactions);
+  } catch (err) {
+    alert(err);
+  }
+}
+
+function displayList(elementId: string, data: any) {
+  const el = document.getElementById(elementId)!;
+  el.textContent = JSON.stringify(data, null, 2);
+}
+
+async function addPerson(ev: Event) {
+  ev.preventDefault();
+  const form = ev.target as HTMLFormElement;
+  const person = {
+    idNumber: (form.elements.namedItem('idNumber') as HTMLInputElement).value,
+    firstName: (form.elements.namedItem('firstName') as HTMLInputElement).value,
+    lastName: (form.elements.namedItem('lastName') as HTMLInputElement).value,
+    dateOfBirth: (form.elements.namedItem('dateOfBirth') as HTMLInputElement).value
+  };
+  await fetchJson(`${API_BASE}/persons`, {
+    method: 'POST',
+    body: JSON.stringify(person)
+  });
+  loadData();
+  form.reset();
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  loadData();
+  const personForm = document.getElementById('personForm') as HTMLFormElement;
+  personForm.addEventListener('submit', addPerson);
+
+  // tsParticles init using global variable from CDN
+  // @ts-ignore
+  tsParticles.load('tsparticles', {
+    particles: {
+      number: { value: 40 },
+      size: { value: 3 },
+      move: { enable: true, speed: 1 }
+    }
+  });
+});

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "es2016",
+    "module": "es2015",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true
+  }
+}


### PR DESCRIPTION
## Summary
- add minimal README
- create demo front-end consuming API via AJAX
- use Tailwind CSS via CDN
- include tsParticles effects

## Testing
- `npx tsc -p frontend`
- `dotnet build Tq.Api/Tq.Api.csproj -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a8116bb508333be0014baac502182